### PR TITLE
[FIX] sale: fixed code than not allow add lines to invoice if lines i…

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -617,9 +617,10 @@ class SaleOrder(models.Model):
                 if line.display_type == 'line_section':
                     pending_section = line
                     continue
-                if float_is_zero(line.qty_to_invoice, precision_digits=precision):
+                if line.display_type != 'line_note' and float_is_zero(
+                    line.qty_to_invoice, precision_digits=precision):
                     continue
-                if line.qty_to_invoice > 0 or (line.qty_to_invoice < 0 and final):
+                if line.qty_to_invoice > 0 or (line.qty_to_invoice < 0 and final) or line.display_type == 'line_note':
                     if pending_section:
                         invoice_vals['invoice_line_ids'].append((0, 0, pending_section._prepare_invoice_line()))
                         pending_section = None


### PR DESCRIPTION
…s a note.

Description of the issue/feature this PR addresses:
This code not allow add line to invoice if the line is a note
Current behavior before PR:
only allow pass line with products or lines type sections
Desired behavior after PR is merged:
It could be add all type lines sections, notes or products.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
