### PR TITLE
[FIX] odoo: remove domain with non-exist field

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -825,12 +825,10 @@ class AccountTaxTemplate(models.Model):
     cash_basis_account_id = fields.Many2one(
         'account.account.template',
         string='Tax Received Account',
-        domain=[('deprecated', '=', False)],
         oldname='cash_basis_account',
         help='Account used as counterpart for the journal entry, for taxes eligible based on payments.')
     cash_basis_base_account_id = fields.Many2one(
         'account.account.template',
-        domain=[('deprecated', '=', False)],
         string='Base Tax Received Account',
         help='Account that will be set on lines created in cash basis journal entry and used to keep track of the tax base amount.')
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Have a domain with field non-existent in model account.account.template

Current behavior before PR:
When you try change value of field cash_basis_base_account_id you get a error wich you can see in log that the field deprecated is no exist, wich us truth this field only exist in model account.account.

Desired behavior after PR is merged:
Now you can change value of this field without problems.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
